### PR TITLE
Add duplicate advancements feature

### DIFF
--- a/src/main/java/io/github/thesummergrinch/growingworld/GrowingWorld.java
+++ b/src/main/java/io/github/thesummergrinch/growingworld/GrowingWorld.java
@@ -1,10 +1,6 @@
 package io.github.thesummergrinch.growingworld;
 
-import io.github.thesummergrinch.growingworld.commands.ClearAdvancementsCommandExecutor;
-import io.github.thesummergrinch.growingworld.commands.SetAllowRecipeAdvancementsCommandExecutor;
-import io.github.thesummergrinch.growingworld.commands.ShrinkWorldBorderCommandExecutor;
-import io.github.thesummergrinch.growingworld.commands.StartWorldBorderExpandingCommandExecutor;
-import io.github.thesummergrinch.growingworld.commands.StopWorldBorderExpandingCommandExecutor;
+import io.github.thesummergrinch.growingworld.commands.*;
 import io.github.thesummergrinch.growingworld.listeners.OnPlayerAdvancementDoneEventHandler;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -48,6 +44,8 @@ public final class GrowingWorld extends JavaPlugin {
                 .setExecutor(new ShrinkWorldBorderCommandExecutor(this.fileConfiguration));
         this.getCommand("setallowrecipeadvancements")
                 .setExecutor(new SetAllowRecipeAdvancementsCommandExecutor(this.fileConfiguration));
+        this.getCommand("setallowduplicateadvancements")
+                .setExecutor(new SetAllowDuplicateAdvancementsCommandExecutor(this.fileConfiguration));
 
     }
 

--- a/src/main/java/io/github/thesummergrinch/growingworld/commands/SetAllowDuplicateAdvancementsCommandExecutor.java
+++ b/src/main/java/io/github/thesummergrinch/growingworld/commands/SetAllowDuplicateAdvancementsCommandExecutor.java
@@ -1,0 +1,47 @@
+package io.github.thesummergrinch.growingworld.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SetAllowDuplicateAdvancementsCommandExecutor implements CommandExecutor, TabCompleter {
+
+    private final FileConfiguration fileConfiguration;
+
+    public SetAllowDuplicateAdvancementsCommandExecutor(final FileConfiguration fileConfiguration) {
+        this.fileConfiguration = fileConfiguration;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+
+        if (sender.isOp() && args.length >= 1) {
+
+            if (args[0].equalsIgnoreCase("true") || args[0].equalsIgnoreCase(
+                    "false")) {
+                this.fileConfiguration.set("allow-duplicate-advancements"
+                        , (args[0].equalsIgnoreCase("true")));
+                return true;
+            }
+
+        }
+        return false;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        return new ArrayList<String>() {
+            {
+                add("true");
+                add("false");
+            }
+        };
+    }
+}

--- a/src/main/java/io/github/thesummergrinch/growingworld/worldborder/WorldBorderController.java
+++ b/src/main/java/io/github/thesummergrinch/growingworld/worldborder/WorldBorderController.java
@@ -3,9 +3,14 @@ package io.github.thesummergrinch.growingworld.worldborder;
 import io.github.thesummergrinch.growingworld.GrowingWorld;
 import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.entity.Player;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -57,6 +62,24 @@ public class WorldBorderController {
 
         final boolean allowRecipeAdvancements =
                 this.fileConfiguration.getBoolean("allow-recipe-advancements");
+
+        final boolean allowDuplicateAdvancements =
+                this.fileConfiguration.getBoolean("allow-duplicate-advancements");
+
+        // Return early if duplicate advancements aren't allowed and this advancement is a duplicate.
+        if (!allowDuplicateAdvancements) {
+            // Get the unique advancements of all players.
+            Set<Advancement> uniqueAdvancements = new HashSet<>();
+            Iterator<Advancement> serverAdvancements = Bukkit.getServer().advancementIterator();
+            while (serverAdvancements.hasNext()) {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    AdvancementProgress progress = player.getAdvancementProgress(serverAdvancements.next());
+                    if (progress.isDone()) uniqueAdvancements.add(progress.getAdvancement());
+                }
+            }
+
+            if (uniqueAdvancements.contains(advancement)) return;
+        }
 
         if (allowRecipeAdvancements || !isRecipeAdvancement) {
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,6 +43,12 @@ config-version: 4
 # blocks whenever a player picks up a new item.
 allow-recipe-advancements: false
 
+# Sets whether or not to count duplicate advancements between players on the server.
+# E.g. if two players have the advancement 'Stone Age' it will be counted both times,
+# but with this option off it would only count as one.
+# Set to true by default.
+allow-duplicate-advancements: true
+
 # Used to determine whether or not the passive world-border growth should be started
 # when the server restarts.
 is-worldborder-expanding: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,9 @@ permissions:
   growingworld.advancement.recipes:
     description: Allows the holder to set whether or not recipe advancements should count towards growing the worldborder.
     default: op
+  growingworld.advancement.duplicates:
+    description: Allows the holder to set whether or not duplicate advancements should count towards growing the worldborder.
+    default: op
 commands:
   clearadvancements:
     usage: /clearadvancements
@@ -48,3 +51,8 @@ commands:
     description: Allows the user to set whether or not recipe advancements should count towards growing the worldborder.
     permission: growingworld.advancement.recipes
     aliases: [ gwrecipes ]
+  setallowduplicateadvancements:
+    usage: /setallowduplicateadvancements or /gwduplicates
+    description: Allows the user to set whether or not duplicate advancements should count towards growing the worldborder.
+    permission: growingworld.advancement.duplicates
+    aliases: [ gwduplicates ]

--- a/target/classes/plugin.yml
+++ b/target/classes/plugin.yml
@@ -22,6 +22,9 @@ permissions:
   growingworld.advancement.recipes:
     description: Allows the holder to set whether or not recipe advancements should count towards growing the worldborder.
     default: op
+  growingworld.advancement.duplicates:
+    description: Allows the holder to set whether or not duplicate advancements should count towards growing the worldborder.
+    default: op
 commands:
   clearadvancements:
     usage: /clearadvancements
@@ -48,3 +51,8 @@ commands:
     description: Allows the user to set whether or not recipe advancements should count towards growing the worldborder.
     permission: growingworld.advancement.recipes
     aliases: [ gwrecipes ]
+  setallowduplicateadvancements:
+    usage: /setallowduplicateadvancements or /gwduplicates
+    description: Allows the user to set whether or not duplicate advancements should count towards growing the worldborder.
+    permission: growingworld.advancement.duplicates
+    aliases: [ gwduplicates ]


### PR DESCRIPTION
Adds a config called allow-duplicate-advancements that determines whether or not to count duplicate advancements between players on the server.
E.g. if two players have the advancement 'Stone Age' it will be counted both times, but with this option off it would only count as one.
This is on by default so behavior doesn't change for current users of the plugin.